### PR TITLE
fix entity tags copying

### DIFF
--- a/Src/Tag/Ecs.Tags.cs
+++ b/Src/Tag/Ecs.Tags.cs
@@ -181,8 +181,8 @@ namespace FFS.Libraries.StaticEcs {
                 var id = BitMask.GetMinIndexBuffer(bufId);
                 while (id >= 0) {
                     _pools[id].Copy(srcEntity, dstEntity);
-                    BitMask.Del(bufId, (ushort) id);
-                    id = BitMask.GetMinIndex(bufId);
+                    BitMask.DelInBuffer(bufId, (ushort) id);
+                    id = BitMask.GetMinIndexBuffer(bufId);
                 }
 
                 BitMask.DropBuf();


### PR DESCRIPTION
Before this fix, only one tag was copied, and tags for some other entity might have been corrupted.