### PR TITLE
Add optional source parameter to events

### DIFF
--- a/Src/Events/Serializer/World.Events.Pool.Serializer.cs
+++ b/Src/Events/Serializer/World.Events.Pool.Serializer.cs
@@ -114,6 +114,7 @@ namespace FFS.Libraries.StaticEcs {
                                         }
                                     }
                                 }
+                                writer.WriteArrayUnmanaged(page.Sources);
                                 count++;
                                 curPageIdx++;
                             }
@@ -158,6 +159,7 @@ namespace FFS.Libraries.StaticEcs {
                                             }
                                         }
                                     }
+                                    reader.ReadArrayUnmanaged(ref page.Sources);
                                 } else {
                                     uint oneSize = default;
                                     if (isUnmanaged) {

--- a/Src/Events/World.Event.cs
+++ b/Src/Events/World.Event.cs
@@ -36,7 +36,17 @@ namespace FFS.Libraries.StaticEcs {
                     #if FFS_ECS_DEBUG
                     if (_eventIdx < 0) throw new StaticEcsException($"[ World<{typeof(WorldType)}>.Event<{typeof(E)}>.Value ] event is deleted");
                     #endif
-                    return ref Events.Pool<E>.Value.Get(_eventIdx);
+                    return ref Events.Pool<E>.Value.GetData(_eventIdx);
+                }
+            }
+            
+            public ref Entity Source {
+                [MethodImpl(AggressiveInlining)]
+                get {
+                    #if FFS_ECS_DEBUG
+                    if (_eventIdx < 0) throw new StaticEcsException($"[ World<{typeof(WorldType)}>.Event<{typeof(E)}>.Value ] event is deleted");
+                    #endif
+                    return ref Events.Pool<E>.Value.GetSource(_eventIdx);
                 }
             }
 

--- a/Src/Events/World.Events.Pool.cs
+++ b/Src/Events/World.Events.Pool.cs
@@ -61,7 +61,7 @@ namespace FFS.Libraries.StaticEcs {
     #endif
     public readonly struct EventPoolWrapper<WorldType, T> : IEventPoolWrapper where T : struct, IEvent where WorldType : struct, IWorldType {
         [MethodImpl(AggressiveInlining)]
-        internal ref T Get(int idx) => ref World<WorldType>.Events.Pool<T>.Value.Get(idx);
+        internal ref T GetData(int idx) => ref World<WorldType>.Events.Pool<T>.Value.GetData(idx);
 
         [MethodImpl(AggressiveInlining)]
         public bool Add(T value) => World<WorldType>.Events.Pool<T>.Value.Add(value);
@@ -76,7 +76,7 @@ namespace FFS.Libraries.StaticEcs {
         Type IEventPoolWrapper.GetEventType() => typeof(T);
 
         [MethodImpl(AggressiveInlining)]
-        IEvent IEventPoolWrapper.GetRaw(int idx) => World<WorldType>.Events.Pool<T>.Value.Get(idx);
+        IEvent IEventPoolWrapper.GetRaw(int idx) => World<WorldType>.Events.Pool<T>.Value.GetData(idx);
 
         [MethodImpl(AggressiveInlining)]
         void IEventPoolWrapper.Destroy() => World<WorldType>.Events.Pool<T>.Value.Destroy();
@@ -85,7 +85,7 @@ namespace FFS.Libraries.StaticEcs {
         public bool AddRaw(IEvent value) => World<WorldType>.Events.Pool<T>.Value.Add((T) value);
 
         [MethodImpl(AggressiveInlining)]
-        void IEventPoolWrapper.PutRaw(int idx, IEvent value) => World<WorldType>.Events.Pool<T>.Value.Get(idx) = (T) value;
+        void IEventPoolWrapper.PutRaw(int idx, IEvent value) => World<WorldType>.Events.Pool<T>.Value.GetData(idx) = (T) value;
 
         [MethodImpl(AggressiveInlining)]
         void IEventPoolWrapper.Clear() => World<WorldType>.Events.Pool<T>.Value.Clear();
@@ -169,6 +169,7 @@ namespace FFS.Libraries.StaticEcs {
                 #endif
                 internal struct Page {
                     internal T[] Data;
+                    internal Entity[] Sources;
                     internal ulong[] Mask;
                     internal ushort[] UnreadReceiversCount;
                     internal ushort Version;
@@ -176,9 +177,11 @@ namespace FFS.Libraries.StaticEcs {
                     [MethodImpl(AggressiveInlining)]
                     public void Free(ref FreePage freePage) {
                         freePage.Data = Data;
+                        freePage.Sources = Sources;
                         freePage.Mask = Mask;
                         freePage.UnreadReceiversCount = UnreadReceiversCount;
                         Data = null;
+                        Sources = null;
                         Mask = null;
                         UnreadReceiversCount = null;
                         Version++;
@@ -187,6 +190,7 @@ namespace FFS.Libraries.StaticEcs {
                     [MethodImpl(AggressiveInlining)]
                     public void FromFree(ref FreePage freePage) {
                         Data = freePage.Data;
+                        Sources = freePage.Sources;
                         Mask = freePage.Mask;
                         UnreadReceiversCount = freePage.UnreadReceiversCount;
                         freePage = default;
@@ -195,6 +199,7 @@ namespace FFS.Libraries.StaticEcs {
                     [MethodImpl(AggressiveInlining)]
                     public void InitNew() {
                         Data = new T[EVENTS_PER_PAGE];
+                        Sources = new Entity[EVENTS_PER_PAGE];
                         Mask = new ulong[MASKS_IN_PAGE];
                         UnreadReceiversCount = new ushort[EVENTS_PER_PAGE];
                     }
@@ -206,6 +211,7 @@ namespace FFS.Libraries.StaticEcs {
                 #endif
                 internal struct FreePage {
                     internal T[] Data;
+                    internal Entity[] Sources;
                     internal ulong[] Mask;
                     internal ushort[] UnreadReceiversCount;
                 }
@@ -298,12 +304,17 @@ namespace FFS.Libraries.StaticEcs {
                 }
                 
                 [MethodImpl(AggressiveInlining)]
-                internal ref T Get(int idx) {
+                internal ref T GetData(int idx) {
                     return ref pages[idx >> EVENT_PAGE_SHIFT].Data[idx & EVENT_PAGE_OFFSET_MASK];
+                }
+                
+                [MethodImpl(AggressiveInlining)]
+                internal ref Entity GetSource(int idx) {
+                    return ref pages[idx >> EVENT_PAGE_SHIFT].Sources[idx & EVENT_PAGE_OFFSET_MASK];
                 }
 
                 [MethodImpl(AggressiveInlining)]
-                internal bool Add(T value = default) {
+                internal bool Add(T value = default, Entity source = default) {
                     #if FFS_ECS_DEBUG
                     if (_blockers > 0) throw new StaticEcsException($"[ World<{typeof(WorldType)}>.Events.Pool<{typeof(T)}>.Add ] event pool cannot be changed, it is in read-only mode");
                     #endif
@@ -324,6 +335,7 @@ namespace FFS.Libraries.StaticEcs {
                         }
 
                         page.Data[inPageIdx] = value;
+                        page.Sources[inPageIdx] = source;
                         page.Mask[maskIdx] |= 1UL << inMaskBit;
                         page.UnreadReceiversCount[inPageIdx] = receiversCount;
                         sequence++;

--- a/Src/Events/World.Events.cs
+++ b/Src/Events/World.Events.cs
@@ -14,7 +14,9 @@ using Unity.IL2CPP.CompilerServices;
 #endif
 
 namespace FFS.Libraries.StaticEcs {
-    public interface IEvents {
+    
+    public interface IEvents
+    {
         public void Send<E>(E value = default) where E : struct, IEvent;
 
         public bool TryGetPool(Type eventType, out IEventPoolWrapper pool);
@@ -25,10 +27,14 @@ namespace FFS.Libraries.StaticEcs {
     [Il2CppSetOption(Option.ArrayBoundsChecks, false)]
     #endif
     public readonly struct EventsWrapper<WorldType> : IEvents where WorldType : struct, IWorldType {
+        
         [MethodImpl(AggressiveInlining)]
-        public void Send<E>(E value = default) where E : struct, IEvent {
-            World<WorldType>.Events.Send(value);
+        public void Send<E>(E value = default, World<WorldType>.Entity source = default) where E : struct, IEvent {
+            World<WorldType>.Events.Send(value, source);
         }
+
+        [MethodImpl(AggressiveInlining)]
+        void IEvents.Send<E>(E value) => World<WorldType>.Events.Send(value);
 
         [MethodImpl(AggressiveInlining)]
         public bool TryGetPool(Type eventType, out IEventPoolWrapper pool) {
@@ -57,13 +63,13 @@ namespace FFS.Libraries.StaticEcs {
 
             #region PUBLIC
             [MethodImpl(AggressiveInlining)]
-            public static bool Send<E>(E value = default) where E : struct, IEvent {
+            public static bool Send<E>(E value = default, Entity source = default) where E : struct, IEvent {
                 #if FFS_ECS_DEBUG
                 if (!IsWorldInitialized()) throw new StaticEcsException($"[ World<{typeof(WorldType)}>.Events.Send<{typeof(E)}> ] Ecs not initialized");
                 if (!Pool<E>.Value.initialized) throw new StaticEcsException($"[ World<{typeof(WorldType)}>.Events.Send<{typeof(E)}> ] Event type {typeof(E)} not registered");
                 if (MultiThreadActive) throw new StaticEcsException($"[ World<{typeof(WorldType)}>.Events.Send<{typeof(E)}> ] this operation is not supported in multithreaded mode");
                 #endif
-                return Pool<E>.Value.Add(value);
+                return Pool<E>.Value.Add(value, source);
             }
 
             [MethodImpl(AggressiveInlining)]


### PR DESCRIPTION
I added this to match a custom implementation I was using on top of Arch ECS. 

Of course, the question that immediately comes to mind is, why not add the source as a field in the event itself? 2 reasons: 

- I have many generic components and systems that can react to different events. For example, a DespawnOn<TEvent> component that can react to collisions, death, etc. So my generic code needs to check the event source without knowing the exact event type. 

- I want to subscribe to and/or check for the presence of events coming from a specific entity. This is not implemented in this PR, and I'd love to hear your take on an efficient way of doing this. 

I don't know if this is something that would be useful in general or just for me, so feel free to reject this PR if it doesn't match your vision for the library.