### PR TITLE
Make reader parameter ref in LoadWorldSnapshot

### DIFF
--- a/Src/World.Serializer.cs
+++ b/Src/World.Serializer.cs
@@ -1037,7 +1037,7 @@ namespace FFS.Libraries.StaticEcs {
             /// entity deletion when clearing the existing world before loading.
             /// Default is <c>false</c>.</param>
             [MethodImpl(AggressiveInlining)]
-            public static void LoadWorldSnapshot(BinaryPackReader reader, bool hardReset = false) {
+            public static void LoadWorldSnapshot(ref BinaryPackReader reader, bool hardReset = false) {
                 #if FFS_ECS_DEBUG
                 AssertWorldIsInitialized(WorldTypeName);
                 #endif


### PR DESCRIPTION
There's no way to get the number of bytes read.

To keep it consistent with the rest of the API, make the reader `ref`.