### PR TITLE
Fix Multi, Link, Links guids for multi-world setup

### DIFF
--- a/Src/Lib.cs
+++ b/Src/Lib.cs
@@ -794,8 +794,8 @@ namespace FFS.Libraries.StaticEcs {
             return $"{typeName}<{genericArgs}>".Replace("+", ".");
         }
 
-        internal static Guid GuidFromAQN(this Type type) {
-            var simplifiedAQN = $"{type.FullName}, {type.Assembly.GetName().Name}".ToLowerInvariant();
+        internal static Guid GuidFromAQN(this Type type, string prefix = null) {
+            var simplifiedAQN = $"{prefix ?? string.Empty}{type.FullName}, {type.Assembly.GetName().Name}".ToLowerInvariant();
 
             using var md5 = MD5.Create();
             var hashBytes = md5.ComputeHash(Encoding.UTF8.GetBytes(simplifiedAQN));

--- a/Src/World.API.cs
+++ b/Src/World.API.cs
@@ -1542,7 +1542,7 @@ namespace FFS.Libraries.StaticEcs {
                 if (default(T) is ILinkConfig<T> cfg) {
                     config = cfg.Config<TWorld>();
                 }
-                RegisterComponentType(config, $"Link<{typeof(T).Name}>", typeof(INonSerializable).IsAssignableFrom(typeof(T)));
+                RegisterLinkComponentType(config);
                 return this;
             }
 
@@ -1558,7 +1558,7 @@ namespace FFS.Libraries.StaticEcs {
                 if (default(T) is ILinksConfig<T> cfg) {
                     config = cfg.Config<TWorld>();
                 }
-                RegisterComponentType(config, $"Links<{typeof(T).Name}>", typeof(INonSerializable).IsAssignableFrom(typeof(T)));
+                RegisterLinksComponentType(config);
                 return this;
             }
 
@@ -1576,7 +1576,7 @@ namespace FFS.Libraries.StaticEcs {
                     config = cfg.Config<TWorld>();
                     elementStrategy = cfg.ElementPackStrategy();
                 }
-                RegisterMultiComponentType(config, elementStrategy, $"Multi<{typeof(T).Name}>");
+                RegisterMultiComponentType(config, elementStrategy);
                 return this;
             }
         }

--- a/Src/World.Data.cs
+++ b/Src/World.Data.cs
@@ -167,6 +167,20 @@ namespace FFS.Libraries.StaticEcs {
             Data.Instance.RegisterComponentOrTagTypeInternal(config, false, nonSerializable ?? typeof(INonSerializable).IsAssignableFrom(typeof(T)), typeName);
         }
 
+		[MethodImpl(AggressiveInlining)]
+		internal static void RegisterLinkComponentType<T>(ComponentTypeConfig<Link<T>> config)
+			where T : unmanaged, ILinkType {
+			config = config.MergeWith(new ComponentTypeConfig<Link<T>>(guid: typeof(T).GuidFromAQN("Link<>")));
+			RegisterComponentType(config, $"Link<{typeof(T).Name}>", typeof(INonSerializable).IsAssignableFrom(typeof(T)));
+		}
+
+		[MethodImpl(AggressiveInlining)]
+		internal static void RegisterLinksComponentType<T>(ComponentTypeConfig<Links<T>> config)
+			where T : unmanaged, ILinksType {
+			config = config.MergeWith(new ComponentTypeConfig<Links<T>>(guid: typeof(T).GuidFromAQN("Links<>")));
+			RegisterComponentType(config, $"Links<{typeof(T).Name}>", typeof(INonSerializable).IsAssignableFrom(typeof(T)));
+		}
+
         /// <summary>
         /// Registers a multi-component type with an optional element serialization strategy.
         /// Sets <see cref="Multi{TValue}.ElementStrategy"/> before component registration.
@@ -175,10 +189,11 @@ namespace FFS.Libraries.StaticEcs {
         /// <param name="config">Component configuration for <see cref="Multi{T}"/>.</param>
         /// <param name="elementStrategy">Serialization strategy for elements. Null uses default <c>StructPackArrayStrategy</c>.</param>
         [MethodImpl(AggressiveInlining)]
-        internal static void RegisterMultiComponentType<T>(ComponentTypeConfig<Multi<T>> config, IPackArrayStrategy<T> elementStrategy, string typeName)
+        internal static void RegisterMultiComponentType<T>(ComponentTypeConfig<Multi<T>> config, IPackArrayStrategy<T> elementStrategy)
             where T : struct, IMultiComponent {
             Multi<T>.ElementStrategy = elementStrategy ?? AutoRegistration.TryCreateUnmanagedPackArrayStrategy<T>() ?? new StructPackArrayStrategy<T>();
-            RegisterComponentType(config, typeName, typeof(INonSerializable).IsAssignableFrom(typeof(T)));
+			config = config.MergeWith(new ComponentTypeConfig<Multi<T>>(guid: typeof(T).GuidFromAQN("Multi<>")));
+            RegisterComponentType(config, $"Multi<{typeof(T).Name}>", typeof(INonSerializable).IsAssignableFrom(typeof(T)));
         }
 
         [MethodImpl(AggressiveInlining)]

--- a/Src/World.MultiComponents.cs
+++ b/Src/World.MultiComponents.cs
@@ -101,7 +101,7 @@ namespace FFS.Libraries.StaticEcs {
                     config = cfg.Config<TWorld>();
                     elementStrategy = cfg.ElementPackStrategy() ?? AutoRegistration.TryCreateUnmanagedPackArrayStrategy<TValue>() ?? new StructPackArrayStrategy<TValue>();
                 }
-                RegisterMultiComponentType(config, elementStrategy, $"Multi<{typeof(TValue).Name}>");
+                RegisterMultiComponentType(config, elementStrategy);
             }
 
             internal uint Offset;

--- a/Src/World.Relations.cs
+++ b/Src/World.Relations.cs
@@ -110,7 +110,7 @@ namespace FFS.Libraries.StaticEcs {
                 if (default(TLinkType) is ILinkConfig<TLinkType> cfg) {
                     config = cfg.Config<TWorld>();
                 }
-                RegisterComponentType(config, $"Link<{typeof(TLinkType).Name}>", typeof(INonSerializable).IsAssignableFrom(typeof(TLinkType)));
+				RegisterLinkComponentType(config);
             }
 
             private EntityGID _value;
@@ -255,7 +255,7 @@ namespace FFS.Libraries.StaticEcs {
                 if (default(TLinkType) is ILinksConfig<TLinkType> cfg) {
                     config = cfg.Config<TWorld>();
                 }
-                RegisterComponentType(config, $"Links<{typeof(TLinkType).Name}>", typeof(INonSerializable).IsAssignableFrom(typeof(TLinkType)));
+                RegisterLinksComponentType(config);
             }
 
             internal uint Offset;


### PR DESCRIPTION
Previously default guids were based on World<>.Link<> types and their AQN, which are world-dependent and break serialization of components across different world types. Made them world-independent.